### PR TITLE
Reload the html after switching 'week' tabs

### DIFF
--- a/delivery-slots.js
+++ b/delivery-slots.js
@@ -49,6 +49,8 @@ async function run() {
       console.log("Opening " + item.url + " [" + item.date + "]");
       await page.goto(item.url);
 
+      html = await page.content();
+
       //if (i<2) {
       if (html.includes("No slots available! Try another day")) {
         console.log("No slots");


### PR DESCRIPTION
I believe you'll need to do this, otherwise the html is only generated once - at initial page load.  You're only ever looking for the "No slots available" string in week 1.  Hard to confirm with the website at the moment, so please check!