### PR TITLE
Fix bug causing no slots to be found

### DIFF
--- a/src/stores/tesco.js
+++ b/src/stores/tesco.js
@@ -133,7 +133,7 @@ class TescoStore {
       console.log("Opening " + slotDate.url + " [" + slotDate.date + "]");
       await goto(page, slotDate.url);
 
-      const deliverySlots = await page.$$(".slot-list--item .available");
+      const deliverySlots = await page.$$(".slot-list--item.available");
 
       if (deliverySlots.length == 0) {
         console.log("No slots");


### PR DESCRIPTION
I found a way for me to test this (by injecting expected html into the page) and yes, there was a bug in it, which caused no slot appearances to be detected. Sorry!

I'd like to extract the selector evaluation out of chrome and into node at some point, so it'll be easier to write unit tests to verify expected behaviour