### PR TITLE
Add file output notifier

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -52,3 +52,6 @@ pushover_notification_users[] = user2key
 
 ; Set to true to have MacOS speak out "Alert! Alert! Alert! We have Tesco delivery slots!" on notifications
 mac_speak = false
+
+; Set to true to save JSON files and screenshots in the output directory
+save_files = true

--- a/src/notifications/file.js
+++ b/src/notifications/file.js
@@ -1,0 +1,50 @@
+const fs = require("fs");
+
+/** @typedef {import("../index").Store} Store */
+/** @typedef {import("../index").SlotDate} SlotDate */
+
+class FileNotifier {
+  _saveFile(outputFile, data, options = "") {
+    fs.writeFile(outputFile, data, options, function (err) {
+      if (err) {
+        return console.log(`Failed to save file ${outputFile}; err = ${err}`);
+      }
+
+      console.log(`Output ${outputFile} saved successfully`);
+    });
+  }
+
+  /**
+   * @param {Store} store
+   * @param {string} type
+   * @param {SlotDate[]} slotDates
+   * @return {Promise<void>}
+   */
+  async sendNotifications(store, type, slotDates) {
+    const data = JSON.stringify(
+      {
+        slotsAvailable: slotDates.length > 0,
+        store: store.name,
+        type: type,
+        slotDates: slotDates.map((slotDate) => {
+          const filename = `output/${store.name}-${slotDate.date}.png`;
+          this._saveFile(filename, slotDate.screenshot, "binary");
+          slotDate.screenshot = new Buffer(filename);
+          return slotDate;
+        }),
+      },
+      null,
+      2
+    );
+
+    this._saveFile(`output/${store.name}-${type}.json`, data);
+  }
+
+  async sendMessage(_) {
+    console.error(
+      "Called FileNotifier.sendMessage(), but there is nothing to do"
+    );
+  }
+}
+
+module.exports = { FileNotifier };

--- a/src/notifiers.js
+++ b/src/notifiers.js
@@ -2,6 +2,7 @@ const config = require("./config");
 const { PushoverNotifier } = require("./notifications/pushover");
 const { TelegramNotifier } = require("./notifications/telegram");
 const { MacSpeakNotifier } = require("./notifications/mac-speak");
+const { FileNotifier } = require("./notifications/file");
 
 /** @typedef {import("./index").Store} Store */
 /** @typedef {import("./index").SlotDate} SlotDate */
@@ -27,6 +28,10 @@ if (config.telegram_api_token) {
 
 if (config.mac_speak) {
   notifiers.push(new MacSpeakNotifier());
+}
+
+if (config.save_files) {
+  notifiers.push(new FileNotifier());
 }
 
 module.exports = notifiers;


### PR DESCRIPTION
This PR adds a simple file output notifier. This is useful to further manipulate data, or, as I will be using it, is create a github actions pipeline that runs this, meaning I can use this without having this running somewhere all the time.